### PR TITLE
New value system, add support for AVX2 and AVX-512

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
 name = "clap"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,7 @@ name = "crypti"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "clap",
  "clap-num",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ iced-x86 = "1.21.0"
 goblin = "0.10"
 clap = { version = "4.5.41", features = ["derive"] }
 clap-num = "1.2.0"
+bytemuck = "1.23.1"
 
 [profile.release]
 lto = true

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,22 +1,76 @@
 use std::collections::{HashMap};
+use bytemuck::{from_bytes, from_bytes_mut, AnyBitPattern, NoUninit};
 
-pub fn get_reg_val(regmap: &HashMap<String, u128>,
-                    reg: &str) -> Option<u128> {
+#[derive(Clone, Copy)]
+pub struct Value {
+    pub data: [u8; 64],
+}
+
+impl Value {
+    /// View the first `size_of::<T>()` bytes of the buffer as a `&T`.
+    #[allow(dead_code)]
+    pub fn as_ref<T>(&self) -> &T
+    where
+        T: AnyBitPattern,
+    {
+        let len = core::mem::size_of::<T>();
+        assert!(
+            len <= self.data.len(),
+            "type {:?} ({} bytes) does not fit into 64-byte buffer",
+            core::any::type_name::<T>(),
+            len,
+        );
+
+        from_bytes(&self.data[..len])
+    }
+
+    /// View the first `size_of::<T>()` bytes of the buffer as a mutable `&T`.
+    #[allow(dead_code)]
+    pub fn as_mut<T>(&mut self) -> &mut T
+    where
+        T: AnyBitPattern,
+        T: NoUninit,
+    {
+        let len = core::mem::size_of::<T>();
+        assert!(len <= self.data.len());
+        from_bytes_mut(&mut self.data[..len])
+    }
+
+    /// Get this value reinterpreted as a value of `size` bytes, but zero-extended to a u64.
+    /// `size` must be 8 or more bytes.
+    pub fn as_zex_u64(&self, size: usize) -> u64
+    {
+        assert!(
+            size <= 8,
+            "type ({} bytes) does not fit into 8-byte buffer",
+            size,
+        );
+
+        let mut buf = [0u8; 8];
+        buf[..size].copy_from_slice(&self.data[..size]);
+        *from_bytes(&buf)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Value {
+        let mut data = [0u8; 64];
+        data[..bytes.len()].copy_from_slice(bytes);
+        Value{ data: data }
+    }
+
+    pub fn zero() -> Value {
+        Value{ data: [0; 64] }
+    }
+}
+
+pub fn get_reg_val(regmap: &HashMap<String, Value>,
+                    reg: &str) -> Option<Value> {
     regmap.get(reg).copied()
 }
 
-pub fn set_reg_val(regmap: &mut HashMap<String, u128>,
+pub fn set_reg_val(regmap: &mut HashMap<String, Value>,
                     reg: &str,
-                    val: u128,
+                    val: &Value,
                     size: usize) {
-    let exis: u128 = regmap.get(reg).copied().unwrap_or(0);
-    let size_bits = size * 8;
-    let mask: u128 = match size_bits {
-        128 => !0,
-        _ => (1 << size_bits) - 1
-    };
-    let mask_exis = exis & !mask;
-    let mask_val = val & mask;
-    let new_val = mask_exis | mask_val;
-    regmap.insert(reg.to_string(), new_val);
+    let exis: &mut Value = regmap.entry(reg.to_string()).or_insert(Value{ data: [0; 64] });
+    exis.data[0..size].copy_from_slice(&val.data[0..size]);
 }


### PR DESCRIPTION
- Major rewriting of the system that stores values. Now, they are stored as byte arrays rather than as u128s.
- Major refactoring of the xor instruction analysis.
- Support was added for 256-bit and 512-bit vector instructions (vmovdqa, vmovdqu, vpxor, etc).