### PR TITLE
Refactoring and optimization, fixed register storage

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1,0 +1,346 @@
+use std::collections::{HashMap, HashSet};
+use iced_x86::{Formatter, Instruction, IntelFormatter, Mnemonic, OpKind, Register};
+use crate::mem::{SimMemory, VecMemory};
+use crate::registers::{Value, get_reg_val, set_reg_val};
+
+/// `Some(val, size)` is a known value corresponding to the lowest `size`
+/// bytes of `val`.
+/// 
+/// `None` is an unknown value; the operand had no known value prior to
+/// being read.
+type MaybeValue = Option<(Value, usize)>;
+
+fn reg_as_str(formatter: &mut dyn Formatter,
+                    reg: Register) -> &str {
+    formatter.format_register(reg)
+}
+
+#[allow(dead_code)]
+pub enum InstructionClass {
+    MovOrVectorMov,
+    XorOrVectorXor,
+}
+
+#[allow(dead_code)]
+pub enum EmulatorStopReason {
+    PreInstruction(InstructionClass),
+    PostInstruction(InstructionClass),
+    Nothing,
+}
+
+pub struct ResultInfo {
+    pub instructions_emulated: usize,
+}
+
+#[allow(dead_code)]
+pub enum ReasonResult {
+    InstructionParameters((Instruction, HashMap<String, MaybeValue>)),
+    InstructionResult((Instruction, MaybeValue)),
+    OutOfInstructions,
+}
+
+pub struct EmulatorResult {
+    pub info: ResultInfo,
+    pub reason: ReasonResult,
+}
+
+pub struct Emulator {
+    pub regmap: HashMap<String, Value>,
+    pub vecmem: VecMemory,
+    ignore_once: HashSet<u64>,
+}
+
+impl Emulator {
+    pub fn new() -> Emulator {
+        Emulator { 
+            regmap: HashMap::new(),
+            vecmem: VecMemory::new(),
+            ignore_once: HashSet::new(),
+        }
+    }
+
+    pub fn fmt_operand(
+        &self,
+        formatter: &mut dyn Formatter,
+        instruction: &Instruction,
+        op: u32) -> String
+    {
+        let mut output: String = String::new();
+
+        if let Err(_err) = formatter.format_operand(instruction, &mut output, op) {
+            return "<UNKNOWN VALUE>".to_string();
+        }
+
+        output
+    }
+
+    pub fn load_operand(
+        &self,
+        formatter: &mut dyn Formatter,
+        instruction: &Instruction,
+        op: u32) -> Option<(Value, usize)>
+    {
+        match instruction.op_kind(op) {
+            OpKind::Immediate8 => Some((Value::from_bytes(&instruction.immediate8().to_le_bytes()), 1)),
+            OpKind::Immediate8_2nd => Some((Value::from_bytes(&instruction.immediate8_2nd().to_le_bytes()), 1)),
+            OpKind::Immediate8to16 => Some((Value::from_bytes(&instruction.immediate8to16().to_le_bytes()), 2)),
+            OpKind::Immediate8to32 => Some((Value::from_bytes(&instruction.immediate8to32().to_le_bytes()), 4)),
+            OpKind::Immediate8to64 => Some((Value::from_bytes(&instruction.immediate8to64().to_le_bytes()), 8)),
+            OpKind::Immediate16 => Some((Value::from_bytes(&instruction.immediate16().to_le_bytes()), 2)),
+            OpKind::Immediate32 => Some((Value::from_bytes(&instruction.immediate32().to_le_bytes()), 4)),
+            OpKind::Immediate32to64 => Some((Value::from_bytes(&instruction.immediate32to64().to_le_bytes()), 8)),
+            OpKind::Immediate64 => Some((Value::from_bytes(&instruction.immediate64().to_le_bytes()), 8)),
+            OpKind::Register => {
+                let reg_str = reg_as_str(formatter, instruction.op_register(op));
+                let reg_val = get_reg_val( &self.regmap, reg_str);
+                match reg_val {
+                    Some(val) => Some((val, instruction.op_register(op).size())),
+                    None => None
+                }
+            },
+            OpKind::Memory => {
+                let reg_base = instruction.memory_base();
+                let displacement = instruction.memory_displacement64() as usize;
+                let reg_index = instruction.memory_index();
+                let index_val = match reg_index {
+                    Register::None => Value::zero(),
+                    reg => {
+                        let reg_str = reg_as_str(formatter, reg);
+                        match get_reg_val(&self.regmap, reg_str) {
+                            Some(reg_val) => reg_val,
+                            None => Value::zero(), // TODO: 0 is not a good guess, value is legitimately unknown
+                        }
+                    }
+                };
+                let reg_index_size = reg_index.size();
+                let scale = instruction.memory_index_scale() as usize;
+
+                let total_offset = (index_val.as_zex_u64(reg_index_size) as usize) * scale + displacement;
+                let memory_size = instruction.memory_size().size().min(64);
+
+                let mut arr: [u8; 64] = [0; 64];
+                let result_count = self.vecmem.mem_read( reg_as_str(formatter, reg_base), total_offset as i64, &mut arr[0..memory_size]);
+                
+                if result_count == memory_size {
+                    Some((Value::from_bytes(&arr), memory_size))
+                } else {
+                    None
+                }
+            },
+            _ => None
+        }
+    }
+
+    pub fn store_operand(
+        &mut self,
+        formatter: &mut dyn Formatter,
+        instruction: &Instruction,
+        op: u32,
+        value: &Value,
+        size: usize
+        )
+    {
+        match instruction.op_kind(op) {
+            OpKind::Register => {
+                let reg_str = reg_as_str(formatter, instruction.op_register(op));
+                set_reg_val(&mut self.regmap, reg_str, value, size);
+            },
+            OpKind::Memory => {
+                let reg_base = instruction.memory_base();
+                let displacement = instruction.memory_displacement64() as usize;
+                let reg_index = instruction.memory_index();
+                let index_val = match reg_index {
+                    Register::None => Value::zero(),
+                    reg => {
+                        let reg_str = reg_as_str(formatter, reg);
+                        match get_reg_val(&mut self.regmap, reg_str) {
+                            Some(reg_val) => reg_val,
+                            None => Value::zero(), // TODO: if we don't have a value for the index register then not actually possible to go forward
+                        }
+                    }
+                };
+                let reg_index_size = reg_index.size();
+                let scale = instruction.memory_index_scale() as usize;
+                let total_offset = (index_val.as_zex_u64(reg_index_size) as usize) * scale + displacement;
+                let memory_size = instruction.memory_size().size();
+
+                self.vecmem.mem_write( reg_as_str(formatter, reg_base), total_offset as i64, &value.data[0..memory_size]);
+            },
+            _ => ()
+        };
+    }
+
+    pub fn process_operands(&self,
+        formatter: &mut dyn Formatter,
+        instruction: &Instruction,
+        ops: &Vec<(u32, MaybeValue)>) -> HashMap<String, MaybeValue>
+    {
+        let mut params: HashMap<String, MaybeValue> = HashMap::new();
+
+        for (op, val) in ops.iter().by_ref() {
+            let src_op_fmt = self.fmt_operand(formatter, instruction, *op);
+            params.insert(src_op_fmt, *val);
+        }
+
+        params
+    }
+
+    /// Start emulating until the condition described by `stop_reason` is reached,
+    /// or the emulator runs through all the instructions in `ìnstructions`.
+    pub fn emulate_until(&mut self, instructions: &[Instruction], stop_reason: EmulatorStopReason) -> EmulatorResult {
+        let mut formatter = IntelFormatter::new();
+
+        for (instruction_idx, instruction) in instructions.iter().enumerate().peekable() {
+            match instruction.mnemonic() {
+                Mnemonic::Mov
+                | Mnemonic::Movups
+                | Mnemonic::Movaps
+                | Mnemonic::Movdqa
+                | Mnemonic::Movdqu
+                | Mnemonic::Movapd
+                | Mnemonic::Movupd
+                | Mnemonic::Vmovups
+                | Mnemonic::Vmovupd
+                | Mnemonic::Vmovdqa
+                | Mnemonic::Vmovdqu
+                | Mnemonic::Vmovaps
+                | Mnemonic::Vmovapd => {
+                    /* Determine source operand */
+                    let src = self.load_operand(&mut formatter, instruction, 1);
+
+                    /* If there is a pre instruction type set and this instruction is not in the ignore list
+                     (it was not previously processed by us in the last iteration) then return. */
+                    if let EmulatorStopReason::PreInstruction(InstructionClass::MovOrVectorMov) = stop_reason {
+                        let ops = vec![(1, src)];
+                        let params: HashMap<String, MaybeValue> = self.process_operands(&mut formatter, instruction, &ops);
+
+                        return EmulatorResult {
+                            info: ResultInfo { instructions_emulated: instruction_idx },
+                            reason: ReasonResult::InstructionParameters((*instruction, params))
+                        };
+                    }
+
+                    /* Only if we got some value based on the source operand */
+                    if let Some((src_val, src_size)) = &src {
+                        /* Act depending on destination operand */
+                        self.store_operand(&mut formatter, instruction, 0, src_val, *src_size);
+                    }
+
+                    /* If there is a post instruction type set, return with the result. */
+                    if let EmulatorStopReason::PostInstruction(InstructionClass::MovOrVectorMov) = stop_reason {
+                        return EmulatorResult {
+                            info: ResultInfo { instructions_emulated: instruction_idx + 1 },
+                            reason: ReasonResult::InstructionResult((*instruction, src))
+                        };
+                    }
+                },
+                Mnemonic::Xorps
+                | Mnemonic::Xorpd
+                | Mnemonic::Xor => {
+                    /* Determine source operand */
+                    let src = self.load_operand(&mut formatter, instruction, 1);
+                    let dest = self.load_operand(&mut formatter, instruction, 0);
+
+                    if let EmulatorStopReason::PreInstruction(InstructionClass::XorOrVectorXor) = stop_reason {
+                        self.ignore_once.insert(instruction.ip());
+
+                        let ops = vec![(0, dest), (1, src)];
+                        let params: HashMap<String, MaybeValue> = self.process_operands(&mut formatter, instruction, &ops);
+
+                        return EmulatorResult {
+                            info: ResultInfo { instructions_emulated: instruction_idx },
+                            reason: ReasonResult::InstructionParameters((*instruction, params))
+                        };
+                    }
+
+                    let result: MaybeValue = dest.as_ref()
+                        .zip(src.as_ref())
+                        .map(|((dest_val, dest_size), (src_val, src_size))| {
+                            let minsize: usize = (*dest_size).min(*src_size);
+                            let mask: u64 = if *src_size == 64 { !0 } else { (1 << minsize) - 1 };
+                            (dest_val.map_bytewise_masked(src_val, mask, |x, y| x ^ y), minsize)
+                        });
+
+                    match &result {
+                        Some((result_val, result_size)) => {
+                            self.store_operand(&mut formatter, instruction, 0, result_val, *result_size);
+
+                        },
+                        None => (),
+                    }
+
+                    if let EmulatorStopReason::PostInstruction(InstructionClass::XorOrVectorXor) = stop_reason {
+                        return EmulatorResult {
+                            info: ResultInfo { instructions_emulated: instruction_idx + 1 },
+                            reason: ReasonResult::InstructionResult((*instruction, result))
+                        };
+                    }
+                    
+                },
+                Mnemonic::Vxorps
+                | Mnemonic::Vxorpd
+                | Mnemonic::Vpxor
+                | Mnemonic::Vpxord
+                | Mnemonic::Vpxorq => {
+                    /* Determine source operands */
+                    let src1 = self.load_operand(&mut formatter, instruction, 1);
+                    let src2 = self.load_operand(&mut formatter, instruction, 2);
+                    let dest = self.load_operand(&mut formatter, instruction, 0);
+
+                    if let EmulatorStopReason::PreInstruction(InstructionClass::XorOrVectorXor) = stop_reason {
+                        self.ignore_once.insert(instruction.ip());
+
+                        let ops = vec![(0, dest), (1, src1), (2, src2)];
+                        let params: HashMap<String, MaybeValue> = self.process_operands(&mut formatter, instruction, &ops);
+
+                        return EmulatorResult {
+                            info: ResultInfo { instructions_emulated: instruction_idx },
+                            reason: ReasonResult::InstructionParameters((*instruction, params))
+                        };
+                    }
+
+                    let result: MaybeValue = src1.as_ref()
+                        .zip(src2.as_ref())
+                        .map(|((dest_val, dest_size), (src_val, src_size))| {
+                            let minsize: usize = (*dest_size).min(*src_size);
+                            let mask: u64 = if *src_size == 64 { !0 } else { (1 << minsize) - 1 };
+                            (dest_val.map_bytewise_masked(src_val, mask, |x, y| x ^ y), minsize)
+                        });
+
+                    match &result {
+                        Some((result_val, result_size)) => {
+                            self.store_operand(&mut formatter, instruction, 0, result_val, *result_size);
+
+                        },
+                        None => (),
+                    }
+
+                    if let EmulatorStopReason::PostInstruction(InstructionClass::XorOrVectorXor) = stop_reason {
+                        return EmulatorResult {
+                            info: ResultInfo { instructions_emulated: instruction_idx + 1 },
+                            reason: ReasonResult::InstructionResult((*instruction, result))
+                        };
+                    }
+                }
+                _ => ()
+            };
+        }
+
+        EmulatorResult {
+            info: ResultInfo { instructions_emulated: instructions.len() },
+            reason: ReasonResult::OutOfInstructions
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_emu_move_instruction() {
+        let emu = Emulator::new();
+        
+        
+    }
+}

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -12,7 +12,9 @@ type MaybeValue = Option<(Value, usize)>;
 
 fn reg_as_str(formatter: &mut dyn Formatter,
                     reg: Register) -> &str {
-    formatter.format_register(reg)
+    // Get the full register, this way AL maps to the
+    // same register as EAX, RAX, etc.
+    formatter.format_register(reg.full_register())
 }
 
 #[allow(dead_code)]

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -332,7 +332,7 @@ impl Emulator {
                             reason: ReasonResult::InstructionResult((*instruction, result))
                         };
                     }
-                }
+                },
                 _ => ()
             };
         }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -71,7 +71,6 @@ impl Emulator {
 
     pub fn load_operand(
         &self,
-        formatter: &mut dyn Formatter,
         instruction: &Instruction,
         op: u32) -> Option<(Value, usize)>
     {
@@ -126,7 +125,6 @@ impl Emulator {
 
     pub fn store_operand(
         &mut self,
-        formatter: &mut dyn Formatter,
         instruction: &Instruction,
         op: u32,
         value: &Value,
@@ -197,7 +195,7 @@ impl Emulator {
                 | Mnemonic::Vmovaps
                 | Mnemonic::Vmovapd => {
                     /* Determine source operand */
-                    let src = self.load_operand(&mut formatter, instruction, 1);
+                    let src = self.load_operand(instruction, 1);
 
                     /* If there is a pre instruction type set and this instruction is not in the ignore list
                      (it was not previously processed by us in the last iteration) then return. */
@@ -214,7 +212,7 @@ impl Emulator {
                     /* Only if we got some value based on the source operand */
                     if let Some((src_val, src_size)) = &src {
                         /* Act depending on destination operand */
-                        self.store_operand(&mut formatter, instruction, 0, src_val, *src_size);
+                        self.store_operand(instruction, 0, src_val, *src_size);
                     }
 
                     /* If there is a post instruction type set, return with the result. */
@@ -229,8 +227,8 @@ impl Emulator {
                 | Mnemonic::Xorpd
                 | Mnemonic::Xor => {
                     /* Determine source operand */
-                    let src = self.load_operand(&mut formatter, instruction, 1);
-                    let dest = self.load_operand(&mut formatter, instruction, 0);
+                    let src = self.load_operand(instruction, 1);
+                    let dest = self.load_operand(instruction, 0);
 
                     if let EmulatorStopReason::PreInstruction(InstructionClass::XorOrVectorXor) = stop_reason {
                         self.ignore_once.insert(instruction.ip());
@@ -254,7 +252,7 @@ impl Emulator {
 
                     match &result {
                         Some((result_val, result_size)) => {
-                            self.store_operand(&mut formatter, instruction, 0, result_val, *result_size);
+                            self.store_operand(instruction, 0, result_val, *result_size);
 
                         },
                         None => (),
@@ -274,9 +272,9 @@ impl Emulator {
                 | Mnemonic::Vpxord
                 | Mnemonic::Vpxorq => {
                     /* Determine source operands */
-                    let src1 = self.load_operand(&mut formatter, instruction, 1);
-                    let src2 = self.load_operand(&mut formatter, instruction, 2);
-                    let dest = self.load_operand(&mut formatter, instruction, 0);
+                    let src1 = self.load_operand(instruction, 1);
+                    let src2 = self.load_operand(instruction, 2);
+                    let dest = self.load_operand(instruction, 0);
 
                     if let EmulatorStopReason::PreInstruction(InstructionClass::XorOrVectorXor) = stop_reason {
                         self.ignore_once.insert(instruction.ip());
@@ -300,7 +298,7 @@ impl Emulator {
 
                     match &result {
                         Some((result_val, result_size)) => {
-                            self.store_operand(&mut formatter, instruction, 0, result_val, *result_size);
+                            self.store_operand(instruction, 0, result_val, *result_size);
 
                         },
                         None => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod mem;
 mod registers;
 mod analysis;
 mod cfg;
+mod emulator;
 mod xmmxor;
 
 use crate::analysis::{Analysis, AnalysisOpts, AnalysisSet};

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -11,6 +11,7 @@ pub trait SimMemory {
 
     /// Shift all offsets for the submemory of `register`
     /// by `offset`.
+    #[allow(dead_code)]
     fn mem_shift(&mut self, register: u64, offset: i64);
 }
 

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -77,16 +77,16 @@ impl Value {
     }
 }
 
-pub fn get_reg_val(regmap: &HashMap<String, Value>,
-                    reg: &str) -> Option<Value> {
-    regmap.get(reg).copied()
+pub fn get_reg_val(regmap: &HashMap<u64, Value>,
+                    reg: u64) -> Option<Value> {
+    regmap.get(&reg).copied()
 }
 
-pub fn set_reg_val(regmap: &mut HashMap<String, Value>,
-                    reg: &str,
+pub fn set_reg_val(regmap: &mut HashMap<u64, Value>,
+                    reg: u64,
                     val: &Value,
                     size: usize) {
-    let exis: &mut Value = regmap.entry(reg.to_string()).or_insert(Value{ data: [0; 64] });
+    let exis: &mut Value = regmap.entry(reg).or_insert(Value{ data: [0; 64] });
     exis.data[0..size].copy_from_slice(&val.data[0..size]);
 }
 

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -60,6 +60,21 @@ impl Value {
     pub fn zero() -> Value {
         Value{ data: [0; 64] }
     }
+
+    pub fn map_bytewise_masked<F: Fn(u8, u8) -> u8>(&self, val2: &Value, mask: u64, f: F) -> Value {
+        let data = self.data
+            .iter()
+            .zip(val2.data.iter())
+            .enumerate()
+            .map(|(pos, (a, b))| match mask & (1 << pos) { 0 => *a, _ => f(*a, *b) } )
+            .collect::<Vec<u8>>()
+            .try_into()
+            .unwrap();
+
+        Value {
+            data: data
+        }
+    }
 }
 
 pub fn get_reg_val(regmap: &HashMap<String, Value>,
@@ -73,4 +88,54 @@ pub fn set_reg_val(regmap: &mut HashMap<String, Value>,
                     size: usize) {
     let exis: &mut Value = regmap.entry(reg.to_string()).or_insert(Value{ data: [0; 64] });
     exis.data[0..size].copy_from_slice(&val.data[0..size]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_bytewise_one_byte() {
+        let val1 = Value::from_bytes(&[0xE4]);
+        let val2 = Value::from_bytes(&[0x34]);
+
+        let result = val1.map_bytewise_masked(&val2, !0, |a, b| a ^ b);
+        let expected = Value::from_bytes(&[0xE4 ^ 0x34]);
+
+        assert_eq!(result.data, expected.data);
+    }
+
+    #[test]
+    fn test_map_bytewise_several_bytes() {
+        let val1 = Value::from_bytes(&[0xE4, 0x22, 0x52, 0x43, 0x59]);
+        let val2 = Value::from_bytes(&[0x34, 0x29, 0x00, 0x34, 0x42]);
+
+        let result = val1.map_bytewise_masked(&val2, !0, |a, b| a ^ b);
+        let expected = Value::from_bytes(&[
+            0xE4 ^ 0x34,
+            0x22 ^ 0x29,
+            0x52 ^ 0x00,
+            0x43 ^ 0x34,
+            0x59 ^ 0x42,
+        ]);
+
+        assert_eq!(result.data, expected.data);
+    }
+
+    #[test]
+    fn test_map_bytewise_several_bytes_partial_mask() {
+        let val1 = Value::from_bytes(&[0xE4, 0x22, 0x52, 0x43, 0x59]);
+        let val2 = Value::from_bytes(&[0x34, 0x29, 0x12, 0x34, 0x42]);
+
+        let result = val1.map_bytewise_masked(&val2,  (1 << 3) - 1, |a, b| a ^ b);
+        let expected = Value::from_bytes(&[
+            0xE4 ^ 0x34,
+            0x22 ^ 0x29,
+            0x52 ^ 0x12,
+            0x43,
+            0x59,
+        ]);
+
+        assert_eq!(result.data, expected.data);
+    }
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -78,16 +78,39 @@ impl Value {
 }
 
 pub fn get_reg_val(regmap: &HashMap<u64, Value>,
-                    reg: u64) -> Option<Value> {
-    regmap.get(&reg).copied()
+                    reg: u64,
+                    lowhigh: usize) -> Option<Value> {
+    if lowhigh == 0 {
+        regmap.get(&reg).copied()
+    } else {
+        match regmap.get(&reg) {
+            Some(val) => {
+                let mut data: [u8; 64] = [0u8; 64];
+
+                for (i, byte) in val.data.iter().copied().skip(lowhigh).enumerate() {
+                    data[i] = byte;
+                }
+
+                Some(Value {
+                    data: data,
+                })
+            },
+            None => None
+        }
+    }
 }
 
 pub fn set_reg_val(regmap: &mut HashMap<u64, Value>,
                     reg: u64,
                     val: &Value,
-                    size: usize) {
+                    size: usize,
+                    lowhigh: usize) {
     let exis: &mut Value = regmap.entry(reg).or_insert(Value{ data: [0; 64] });
-    exis.data[0..size].copy_from_slice(&val.data[0..size]);
+    if lowhigh == 0 {
+        exis.data[0..size].copy_from_slice(&val.data[0..size]);
+    } else {
+        exis.data[lowhigh..lowhigh+size].copy_from_slice(&val.data[0..size]);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Heavy refactoring of emulation code, separating it from the XmmXor analysis logic and making it reusable for possible new analyses in the future.
- Various optimizations.
- Small fixes to emulated register and value storage. Instructions such as `mov ah, 0x20` and `mov rax, 0x50000` affect the same underlying memory, which improves emulation accuracy in some scenarios.