### PR TITLE
Add hash algorithm detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
-.test.dll
+.test*.dll
 /distrib

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -8,6 +8,7 @@ use crate::{loader::Binary, log::LogLevel};
 pub enum AnalysisResultType {
     CFG,
     XmmXor,
+    Hash,
 }
 
 pub struct AnalysisOpts {
@@ -20,7 +21,8 @@ impl fmt::Display for AnalysisResultType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", match self {
             AnalysisResultType::CFG => "CFG",
-            AnalysisResultType::XmmXor => "XmmXor"
+            AnalysisResultType::XmmXor => "XmmXor",
+            AnalysisResultType::Hash => "Hash",
         })
     }
 }

--- a/src/hashconst.rs
+++ b/src/hashconst.rs
@@ -1,0 +1,76 @@
+use crate::registers::Value;
+
+pub fn known_hash_u32(hash_value: u32) -> Option<String> {
+    match hash_value {
+        0x4F727068
+        | 0x65616E42
+        | 0x65686F6C
+        | 0x64657253
+        | 0x63727944
+        | 0x6F756274 => Some("BCRYPT".to_string()),
+        0x67452301
+        | 0xefcdab89
+        | 0x98badcfe
+        | 0x10325476 => Some("MD4/MD5/SHA1".to_string()),
+        0xc3d2e1f0
+        | 0x5a827999
+        | 0x6ed9eba1
+        | 0x8f1bbcdc
+        | 0xca62c1d6 => Some("SHA1".to_string()),
+        0xc1059ed8
+        | 0x367cd507
+        | 0x3070dd17
+        | 0xf70e5939
+        | 0xffc00b31
+        | 0x68581511
+        | 0x64f98fa7
+        | 0xbefa4fa4 => Some("SHA224".to_string()),
+        0x6a09e667
+        | 0xbb67ae85
+        | 0x3c6ef372
+        | 0xa54ff53a
+        | 0x510e527f
+        | 0x9b05688c
+        | 0x1f83d9ab
+        | 0x5be0cd19 => Some("SHA256".to_string()),
+        _ => None
+    }
+}
+
+pub fn known_hash_u64(hash_value: u64) -> Option<String> {
+    match hash_value {
+        0x736f6d6570736575
+        | 0x646f72616e646f6d
+        | 0x6c7967656e657261
+        | 0x7465646279746573 => Some("SIPHASH".to_string()),
+        0xcbbb9d5dc1059ed8
+        | 0x629a292a367cd507
+        | 0x9159015a3070dd17
+        | 0x152fecd8f70e5939
+        | 0x67332667ffc00b31
+        | 0x8eb44a8768581511
+        | 0xdb0c2e0d64f98fa7
+        | 0x47b5481dbefa4fa4 => Some("SHA384".to_string()),
+        0x6a09e667f3bcc908
+        | 0xbb67ae8584caa73b
+        | 0x3c6ef372fe94f82b
+        | 0xa54ff53a5f1d36f1
+        | 0x510e527fade682d1
+        | 0x9b05688c2b3e6c1f
+        | 0x1f83d9abfb41bd6b
+        | 0x5be0cd19137e2179 => Some("SHA512".to_string()),
+        _ => None
+    }
+}
+
+pub fn is_known_hash_func(hash_value: &Value, size: usize) -> Option<String> {
+    let as_u32 = {
+        if size >= 4 { known_hash_u32(hash_value.as_zex_u32(4)) } else { None }
+    };
+
+    let as_u64 = {
+        if size >= 8 { known_hash_u64(hash_value.as_zex_u64(8)) } else { None }
+    };
+
+    return as_u32.or(as_u64);
+}

--- a/src/hashfunc.rs
+++ b/src/hashfunc.rs
@@ -1,0 +1,109 @@
+use std::collections::{HashMap, HashSet};
+use iced_x86::{Instruction, Mnemonic};
+use anyhow::Result;
+
+use crate::analysis::{Analysis, AnalysisOpts, AnalysisResult, AnalysisResultType, AnalysisSet};
+use crate::cfg::{BasicBlock, CFGAnalysisResult};
+use crate::emulator::{Emulator, ResultInfo, ReasonResult, EmulatorResult, EmulatorStopReason, InstructionClass};
+use crate::loader::{Binary};
+use crate::hashconst::is_known_hash_func;
+
+pub struct HashAnalysisResult {
+    pub function_hash_algos: HashMap<u64, HashSet<String>>,
+}
+
+impl AnalysisResult for HashAnalysisResult {
+    fn get_type(&self) -> AnalysisResultType {
+        AnalysisResultType::Hash
+    }
+
+    fn print_result(&self) {
+        println!("[---------Hashfunc Analysis--------]");
+        for (func_start, hash_algos) in self.function_hash_algos.iter() {
+            print!("sub_{:X}", func_start);
+            let as_vec: Vec<String> = hash_algos.iter().map(|algo| algo.clone()).collect();
+            println!(" -> {}", as_vec.join(","));
+        }
+
+        if self.function_hash_algos.len() == 0 {
+            println!("No hash algorithms detected.");
+        }
+    }
+}
+
+pub struct HashAnalysis {}
+
+pub fn try_hash_analysis(_opts: &AnalysisOpts, basic_block: &BasicBlock) -> HashSet<String> {
+    let mut emu: Emulator = Emulator::new();
+    let mut detected_algos: HashSet<String> = HashSet::new();
+    let mut idx: usize = 0;
+
+    loop {
+        let instructions: &[Instruction] = &basic_block.instructions[idx..basic_block.instructions.len()];
+
+        let EmulatorResult{ 
+            info: ResultInfo{ instructions_emulated },
+            reason: reason_result
+        } = emu.emulate_until(instructions, EmulatorStopReason::PostInstruction(InstructionClass::MovOrVectorMov));
+
+        if let ReasonResult::InstructionResult(mov_result) = reason_result {
+            if let (_instruction, Some((mov_data, mov_size))) = &mov_result {
+                if let Some(hash_algo) = is_known_hash_func(mov_data, *mov_size) {
+                    detected_algos.insert(hash_algo);
+                }
+            }
+        } else if let ReasonResult::OutOfInstructions = reason_result {
+            break;
+        }
+
+        idx += instructions_emulated;
+    }
+
+
+    detected_algos
+}
+
+fn block_contains_xor(basic_block: &BasicBlock) -> bool {
+    let is_xor = |instruction: &Instruction| {
+        match instruction.mnemonic() {
+            Mnemonic::Xor
+            | Mnemonic::Xorps
+            | Mnemonic::Xorpd
+            | Mnemonic::Vxorps
+            | Mnemonic::Vxorpd
+            | Mnemonic::Vpxor
+            | Mnemonic::Vpxord
+            | Mnemonic::Vpxorq => true,
+            _ => false
+        }
+    };
+
+    basic_block.instructions.iter().find(|&instruction| is_xor(instruction)).is_some()
+}
+
+impl Analysis for HashAnalysis {
+    fn analyze(&self, analyses: &AnalysisSet, _binary: &Binary) -> Result<Box<dyn AnalysisResult>> {
+        let cfg_result = analyses.get_of_type(AnalysisResultType::CFG)?
+            .as_type::<CFGAnalysisResult>()?;
+
+        let mut algos_map: HashMap<u64, HashSet<String>> = HashMap::new();
+
+        for (&func_start, func_block) in cfg_result.function_blocks.iter() {
+            if !func_block.basic_blocks.iter().any(| (_block_start, basic_block) | block_contains_xor(basic_block)) {
+                continue;
+            }
+
+            for (&_block_start, basic_block) in &func_block.basic_blocks {
+                let detected_algos = try_hash_analysis(&analyses.opts, basic_block);
+
+                if detected_algos.len() > 0 {
+                    algos_map.entry(func_start).or_insert(HashSet::new()).extend(detected_algos);
+                }
+            }
+        }
+
+        Ok(Box::from(HashAnalysisResult{
+            function_hash_algos: algos_map,
+        }))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod registers;
 mod analysis;
 mod cfg;
 mod emulator;
+mod hashconst;
+mod hashfunc;
 mod xmmxor;
 
 use crate::analysis::{Analysis, AnalysisOpts, AnalysisSet};
@@ -17,6 +19,7 @@ use crate::loader::{load_pe_file};
 use crate::log::LogLevel;
 use crate::cfg::CFGAnalysis;
 use crate::xmmxor::XorAnalysis;
+use crate::hashfunc::HashAnalysis;
 
 const PROGRAM_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -49,6 +52,7 @@ pub fn load_and_analyze(file_path: &str, opts: AnalysisOpts) -> Result<AnalysisS
     };
 
     analyses.results.push(CFGAnalysis{}.analyze(&analyses, &pebin)?);
+    analyses.results.push(HashAnalysis{}.analyze(&analyses, &pebin)?);
     analyses.results.push(XorAnalysis{}.analyze(&analyses, &pebin)?);
 
     Ok(analyses)

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -36,6 +36,21 @@ impl Value {
         from_bytes_mut(&mut self.data[..len])
     }
 
+    /// Get this value reinterpreted as a value of `size` bytes, but zero-extended to a u32.
+    /// `size` must be 4 or fewer bytes.
+    pub fn as_zex_u32(&self, size: usize) -> u32
+    {
+        assert!(
+            size <= 4,
+            "type ({} bytes) does not fit into 4-byte buffer",
+            size,
+        );
+
+        let mut buf = [0u8; 4];
+        buf[..size].copy_from_slice(&self.data[..size]);
+        *from_bytes(&buf)
+    }
+
     /// Get this value reinterpreted as a value of `size` bytes, but zero-extended to a u64.
     /// `size` must be 8 or fewer bytes.
     pub fn as_zex_u64(&self, size: usize) -> u64


### PR DESCRIPTION
Added a new analysis which attempts to detect common hashing algorithms by searching for algorithm-specific constants.

Currently, the detected algorithms are:

- bcrypt
- SipHash (tested working)
- MD4/MD5
- SHA1
- SHA224
- SHA256
- SHA384
- SHA512

As of writing this, only detection of siphash has been tested and confirmed working to some degree of accuracy.